### PR TITLE
Update import sources to the 4th article, part 2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ registerBlockType('firstgutyblocks/hero-image', {
         },
         fontColor: {
             type: 'string',
-            default: null // let's get rid of the annoying orange
+            default: "" // let's get rid of the annoying orange
         },
         backgroundImage: {
             type: 'string',

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,6 @@
-const {
-    registerBlockType,
-    RichText,
-    InspectorControls,
-    ColorPalette,
-    MediaUpload
-} = wp.blocks;
+const { registerBlockType } = wp.blocks;
+const { RichText, InspectorControls, MediaUpload } = wp.editor;
+const { ColorPalette } = wp.components;
 
 registerBlockType('firstgutyblocks/hero-image', {
     title: "Hero Image Block",


### PR DESCRIPTION
## Description
I updated RichText, InspectorControls, ColorPalette and MediaUpload import source so it was compatible with the newest version of Gutenberg. The previous import was breaking the code. 

I also fixed issue with an error displayed while trying to change the font color without inserting any text.

## Checklist
- [x] I've tested the code
